### PR TITLE
Add role-based authentication and seed data for user roles

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -13,6 +13,7 @@ jobs:
     name: dotnet-build
     env:
       MediatR__LicenseKey: ${{ secrets.MEDIATR_LICENSE_KEY }}
+      AdminUser__Password: ${{ secrets.ADMINUSER_PASSWORD }}
     runs-on: ubuntu-latest
 
     steps:

--- a/src/ExpenseModule/ExpenseTracker.Expenses.Tests/Abstractions/IntegrationTestWebAppFactory.cs
+++ b/src/ExpenseModule/ExpenseTracker.Expenses.Tests/Abstractions/IntegrationTestWebAppFactory.cs
@@ -22,6 +22,7 @@ public class IntegrationTestWebAppFactory : WebApplicationFactory<Program>, IAsy
 
   protected override void ConfigureWebHost(IWebHostBuilder builder)
   {
+    builder.UseEnvironment("Test");
     builder.ConfigureTestServices(services =>
     {
       services.RemoveAll<DbContextOptions<ExpenseDbContext>>();

--- a/src/ExpenseTracker.WebAPI/Program.cs
+++ b/src/ExpenseTracker.WebAPI/Program.cs
@@ -14,7 +14,7 @@ namespace ExpenseTracker.WebAPI;
 
 public partial class Program
 {
-  private static void Main(string[] args)
+  private static async Task Main(string[] args)
   {
     var builder = WebApplication.CreateBuilder(args);
 
@@ -49,7 +49,7 @@ public partial class Program
     // Set Mediatr
     builder.Services.AddMediatR(cfg =>
     {
-      cfg.RegisterServicesFromAssemblies(mediatRAssemblies.ToArray());
+      cfg.RegisterServicesFromAssemblies([.. mediatRAssemblies]);
       cfg.LicenseKey = builder.Configuration["MediatR:LicenseKey"];
     });
 
@@ -67,9 +67,16 @@ public partial class Program
 
     app.UseFastEndpoints();
 
+    // Seed Data
+    if (!app.Environment.IsEnvironment("Test"))
+    {
+      using var scope = app.Services.CreateScope();
+      await SeedData.InitiliazeAsync(scope.ServiceProvider, builder.Configuration);
+    }
+
     app.MapHealthChecks("/health");
 
-    app.Run();
+    await app.RunAsync();
   }
 }
 public partial class Program { }

--- a/src/ReceiptModule/ExpenseTracker.Receipts.Tests/Abstractions/IntegrationTestWebAppFactory.cs
+++ b/src/ReceiptModule/ExpenseTracker.Receipts.Tests/Abstractions/IntegrationTestWebAppFactory.cs
@@ -25,6 +25,7 @@ public class IntegrationTestWebAppFactory
   protected override void ConfigureWebHost(
     IWebHostBuilder builder)
   {
+    builder.UseEnvironment("Test");
     builder.ConfigureTestServices(services =>
     {
       services.RemoveAll<DbContextOptions<ReceiptDbContext>>();

--- a/src/TenantModule/ExpenseTracker.Tenants.Tests/Abstractions/IntegrationTestWebAppFactory.cs
+++ b/src/TenantModule/ExpenseTracker.Tenants.Tests/Abstractions/IntegrationTestWebAppFactory.cs
@@ -21,6 +21,7 @@ public class IntegrationTestWebAppFactory : WebApplicationFactory<Program>, IAsy
 
   protected override void ConfigureWebHost(IWebHostBuilder builder)
   {
+    builder.UseEnvironment("Test");
     builder.ConfigureTestServices(services =>
     {
       services.RemoveAll(typeof(DbContextOptions<TenantDbContext>));

--- a/src/UsersModule/ExpenseTracker.Users.Tests/Abstractions/IntegrationTestWebAppFactory.cs
+++ b/src/UsersModule/ExpenseTracker.Users.Tests/Abstractions/IntegrationTestWebAppFactory.cs
@@ -1,5 +1,6 @@
 using ExpenseTracker.Users.Data;
 using ExpenseTracker.WebAPI;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -21,13 +22,21 @@ public class IntegrationTestWebAppFactory : WebApplicationFactory<Program>, IAsy
 
   protected override void ConfigureWebHost(IWebHostBuilder builder)
   {
+    builder.UseEnvironment("Test");
     builder.ConfigureTestServices(services =>
     {
-      services.RemoveAll(typeof(DbContextOptions<UsersDbContext>));
+      services.RemoveAll<DbContextOptions<UsersDbContext>>();
       services.AddDbContextPool<UsersDbContext>(options =>
       {
         options.UseNpgsql(_dbContainer.GetConnectionString());
       });
+
+      services.AddAuthentication(options =>
+      {
+        options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+        options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+      }).AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+          TestAuthHandler.SchemeName, _ => { });
     });
   }
 

--- a/src/UsersModule/ExpenseTracker.Users.Tests/Abstractions/TestAuthHandler.cs
+++ b/src/UsersModule/ExpenseTracker.Users.Tests/Abstractions/TestAuthHandler.cs
@@ -1,0 +1,31 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ExpenseTracker.Users.Tests.Abstractions;
+
+public class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+  public const string SchemeName = "TestScheme";
+
+  protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+  {
+    var claims = new[]
+    {
+      new Claim(ClaimTypes.Role, "SystemAdmin")
+    };
+    var identity = new ClaimsIdentity(claims, SchemeName);
+    var principal = new ClaimsPrincipal(identity);
+    var ticket = new AuthenticationTicket(principal, SchemeName);
+
+    if (Request.Headers.ContainsKey("No-Auth"))
+      return Task.FromResult(AuthenticateResult.Fail("No header"));
+
+    return Task.FromResult(AuthenticateResult.Success(ticket));
+  }
+}

--- a/src/UsersModule/ExpenseTracker.Users/Data/SeedData.cs
+++ b/src/UsersModule/ExpenseTracker.Users/Data/SeedData.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExpenseTracker.Users.Data;
+
+public static class SeedData
+{
+  public static async Task InitiliazeAsync(IServiceProvider serviceProvider, IConfiguration configuration)
+  {
+    var userManager = serviceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+    var roleManager = serviceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+
+    var systemAdmin = "SystemAdmin";
+    var tenantAdmin = "TenantAdmin";
+    var userRole = "User";
+
+    string[] roles = [systemAdmin, tenantAdmin, userRole];
+
+    foreach (var role in roles)
+    {
+      if (!await roleManager.RoleExistsAsync(role))
+      {
+        await roleManager.CreateAsync(new IdentityRole(role));
+      }
+    }
+
+    // first admin user
+    var adminEmail = "admin@expensetracker.com";
+    var adminPassword = configuration["AdminUser:Password"];
+
+    var adminUser = await userManager.FindByEmailAsync(adminEmail);
+    if (adminUser == null)
+    {
+      adminUser = new ApplicationUser
+      {
+        UserName = adminEmail,
+        Email = adminEmail,
+        EmailConfirmed = true,
+        TenantId = Guid.Empty
+      };
+
+      await userManager.CreateAsync(adminUser, adminPassword!);
+      await userManager.AddToRoleAsync(adminUser, systemAdmin);
+    }
+  }
+}

--- a/src/UsersModule/ExpenseTracker.Users/UserEndpoints/Create.cs
+++ b/src/UsersModule/ExpenseTracker.Users/UserEndpoints/Create.cs
@@ -8,7 +8,7 @@ internal class Create(UserManager<ApplicationUser> userManager) : Endpoint<Creat
   public override void Configure()
   {
     Post("/users");
-    AllowAnonymous();
+    Roles("SystemAdmin", "TenantAdmin");
   }
 
   public override async Task HandleAsync(CreateUserRequest req, CancellationToken ct)

--- a/src/UsersModule/ExpenseTracker.Users/UsersModuleServiceExtensions.cs
+++ b/src/UsersModule/ExpenseTracker.Users/UsersModuleServiceExtensions.cs
@@ -1,4 +1,5 @@
 using ExpenseTracker.Users.Data;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ExpenseTracker.Users;
@@ -8,6 +9,7 @@ public static class UsersModuleServiceExtensions
   public static IServiceCollection AddUserModuleServices(this IServiceCollection services)
   {
     services.AddIdentityCore<ApplicationUser>()
+      .AddRoles<IdentityRole>()
       .AddEntityFrameworkStores<UsersDbContext>();
 
     return services;


### PR DESCRIPTION
- Updated the .NET build workflow to include AdminUser password secret.
- Set the environment to "Test" in integration test factories.
- Changed the Main method to async and updated the application run method.
- Implemented a TestAuthHandler for role-based authentication in user tests.
- Created SeedData class to initialize user roles and an admin user.
- Restricted user creation endpoint to SystemAdmin and TenantAdmin roles.
- Enhanced user module services to support role management.